### PR TITLE
fixes for failing imagemagick due to misconfigured configuration files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -4,7 +4,12 @@ indent() {
   sed -u 's/^/       /'
 }
 
-echo "-----> Install ImageMagick"
+# Output helpers
+# shellcheck source=bin/utils
+BIN_DIR=$(cd "$(dirname "$0")"; pwd)
+source "$BIN_DIR/utils"
+
+build-step "Install ImageMagick"
 
 BUILD_DIR=$1
 CACHE_DIR=$2
@@ -12,6 +17,8 @@ VENDOR_DIR="$BUILD_DIR/vendor"
 INSTALL_DIR="$VENDOR_DIR/imagemagick"
 IMAGE_MAGICK_VERSION="${IMAGE_MAGICK_VERSION:-7.0.5-10}"
 CACHE_FILE="$CACHE_DIR/imagemagick-$IMAGE_MAGICK_VERSION.tar.gz"
+CONF_DIR="$BIN_DIR/../conf"
+IMAGE_MAGICK_DIR_STRING="ImageMagick-7"
 
 if [ ! -f $CACHE_FILE ]; then
   # install imagemagick
@@ -19,18 +26,18 @@ if [ ! -f $CACHE_FILE ]; then
   IMAGE_MAGICK_DIR="ImageMagick-$IMAGE_MAGICK_VERSION"
   IMAGE_MAGICK_URL="https://www.imagemagick.org/download/releases/$IMAGE_MAGICK_FILE"
 
-  echo "-----> Downloading ImageMagick from $IMAGE_MAGICK_URL"
+  build-step "Downloading ImageMagick from $IMAGE_MAGICK_URL"
   wget $IMAGE_MAGICK_URL -P $BUILD_DIR | indent
 
-  echo "-----> Extracting ImageMagick from $BUILD_DIR/$IMAGE_MAGICK_FILE"
+  build-step "Extracting ImageMagick from $BUILD_DIR/$IMAGE_MAGICK_FILE"
   if [ ! -f $BUILD_DIR/$IMAGE_MAGICK_FILE ]; then
-    echo "Error: Unable to download ImageMagick" | indent
+    build-step "Error: Unable to download ImageMagick" | indent
     ls $BUILD_DIR | indent
     exit 1;
   fi
   tar xvf $BUILD_DIR/$IMAGE_MAGICK_FILE | indent
 
-  echo "-----> Building ImageMagick"
+  build-step "Building ImageMagick"
   cd $IMAGE_MAGICK_DIR
   export CPPFLAGS="-I$INSTALL_DIR/include"
   export LDFLAGS="-L$INSTALL_DIR/lib"
@@ -40,7 +47,7 @@ if [ ! -f $CACHE_FILE ]; then
   rm -rf $IMAGE_MAGICK_DIR
 
   # cache for future deploys
-  echo "-----> Caching ImageMagick installation"
+  build-step "Caching ImageMagick installation"
   cd $VENDOR_DIR
   REL_INSTALL_DIR="imagemagick"
   tar czf $REL_INSTALL_DIR.tar.gz $REL_INSTALL_DIR
@@ -53,36 +60,25 @@ if [ ! -f $CACHE_FILE ]; then
 
 else
   # cache exists, extract it
-  echo "-----> Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
+  build-step "Extracting ImageMagick $CACHE_FILE => $VENDOR_DIR"
   mkdir -p $VENDOR_DIR
   tar xzf $CACHE_FILE -C $VENDOR_DIR
 fi
 
-echo "-----> Writing policy file"
-mkdir -p $INSTALL_DIR/etc/ImageMagick
-cat > $INSTALL_DIR/policy.xml <<EOF
-<policymap>
-  <policy domain="coder" rights="none" pattern="EPHEMERAL" />
-  <policy domain="coder" rights="none" pattern="HTTPS" />
-  <policy domain="coder" rights="none" pattern="MVG" />
-  <policy domain="coder" rights="none" pattern="MSL" />
-</policymap>
-EOF
-
-echo "-----> Writing config file"
-cat > $INSTALL_DIR/magic.xml <<EOF
-<magicmap>
- <magic name="JPEG" offset="0" target="\377\330\377"/> 
- <magic name="PNG" offset="0" target="\211PNG\r\n\032\n"/> 
-</magicmap>
-EOF
+MAGIC_CONFIG_DIR=$INSTALL_DIR/etc/$IMAGE_MAGICK_DIR_STRING
+build-step "Copying files from $CONF_DIR to $MAGIC_CONFIG_DIR "
+for file in $CONF_DIR/*.*; do
+    build-step "Copying $file to $MAGIC_CONFIG_DIR"
+    cp $file $MAGIC_CONFIG_DIR
+done
 
 # update PATH and LD_LIBRARY_PATH
-echo "-----> Updating environment variables"
+build-step "Updating environment variables"
 PROFILE_PATH="$BUILD_DIR/.profile.d/imagemagick.sh"
 ACTUAL_INSTALL_PATH="$HOME/vendor/imagemagick"
 mkdir -p $(dirname $PROFILE_PATH)
 echo "export PATH=$ACTUAL_INSTALL_PATH/bin:\$PATH" >> $PROFILE_PATH
 echo "export LD_LIBRARY_PATH=$ACTUAL_INSTALL_PATH/lib:\$LD_LIBRARY_PATH:/usr/local/lib" >> $PROFILE_PATH
-echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH" >> $PROFILE_PATH
-echo "-----> Done updating environment variables. All set for ImageMagick."
+build-step "Setting MAGICK_CONFIGURE_PATH to $ACTUAL_INSTALL_PATH/etc/$IMAGE_MAGICK_DIR_STRING"
+echo "export MAGICK_CONFIGURE_PATH=$ACTUAL_INSTALL_PATH/etc/$IMAGE_MAGICK_DIR_STRING" >> $PROFILE_PATH
+build-step "Done updating environment variables. All set for ImageMagick."

--- a/bin/utils
+++ b/bin/utils
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Output helpers
+function build-step (){ echo "-----> $*"; }
+function build-warn (){ echo " !     $*"; }
+function build-info (){ echo "       $*"; }

--- a/conf/magic.xml
+++ b/conf/magic.xml
@@ -1,0 +1,4 @@
+<magicmap>
+  <magic name="JPEG" offset="0" target="\377\330\377"/>
+  <magic name="PNG" offset="0" target="\211PNG\r\n\032\n"/>
+</magicmap>

--- a/conf/policy.xml
+++ b/conf/policy.xml
@@ -1,0 +1,8 @@
+<policymap>
+  <policy domain="resource" name="memory" value="256MiB"/>
+  <policy domain="resource" name="map" value="512MiB"/>
+  <policy domain="resource" name="width" value="80KP"/>
+  <policy domain="resource" name="height" value="80KP"/>
+  <policy domain="resource" name="area" value="128MB"/>
+  <policy domain="resource" name="disk" value="25GiB"/>
+</policymap>


### PR DESCRIPTION
imagemagick wasn't finding its configuration files due to a misconfigured path, this PR fixes that as well as increases the size limits allowed.

the results are im-ci is now working again!


im ci image magick failure [ch1931]